### PR TITLE
Allow more content types to fix issue with Firefox on Windows.

### DIFF
--- a/tests/contribution/api/integration/post_contribution_test.py
+++ b/tests/contribution/api/integration/post_contribution_test.py
@@ -19,7 +19,7 @@ def test_write_file_error(auth_server):
             live_server.url, c.contribution_post0, cookies=cookies
         )
         assert rsp.status_code == 500
-        assert rsp.json() == dict(msg="Could not save the uploaded file.")
+        assert rsp.json() == {"msg": "Could not save the uploaded file."}
 
 
 def test_write_db_error(auth_server):
@@ -34,9 +34,9 @@ def test_write_db_error(auth_server):
             live_server.url, c.contribution_post0, cookies=cookies
         )
         assert rsp.status_code == 500
-        assert rsp.json() == dict(
-            msg="Could not store the contribution in the database."
-        )
+        assert rsp.json() == {
+            "msg": "Could not store the contribution in the database."
+        }
 
 
 def test_wrong_content_type(auth_server):
@@ -45,7 +45,9 @@ def test_wrong_content_type(auth_server):
         live_server.url,
         c.contribution_post0,
         cookies=cookies,
-        content_type="text/plain",
+        content_type="text/unknown",
     )
     assert rsp.status_code == 400
-    assert rsp.json() == dict(msg="Invalid content type. Only text/csv allowed.")
+    assert rsp.json() == {
+        "msg": "Invalid content type. Only text/csv, text/plain, text/x-csv, application/vnd.ms-excel, application/csv, application/x-csv, text/csv, text/comma-separated-values, text/x-comma-separated-values, text/tab-separated-values allowed."  # pylint: disable=line-too-long
+    }

--- a/vran/contribution/api.py
+++ b/vran/contribution/api.py
@@ -31,7 +31,18 @@ router.add_router(
     "/{id_contribution_persistent}/entities", entity_router, auth=vran_auth
 )
 
-ALLOWED_CONTENT_TYPES = ["text/csv"]
+ALLOWED_CONTENT_TYPES = [
+    "text/csv",
+    "text/plain",
+    "text/x-csv",
+    "application/vnd.ms-excel",
+    "application/csv",
+    "application/x-csv",
+    "text/csv",
+    "text/comma-separated-values",
+    "text/x-comma-separated-values",
+    "text/tab-separated-values",
+]
 
 
 @router.post(
@@ -46,11 +57,11 @@ def contribution_post(
     "Create a new contribution"
     try:
         content_type = file.content_type
-        if content_type == "text/csv":
+        if content_type in ALLOWED_CONTENT_TYPES:
             extension = ".csv"
         else:
             return 400, ApiError(
-                msg=f"Invalid content type. Only {','.join(ALLOWED_CONTENT_TYPES)} allowed."
+                msg=f"Invalid content type. Only {', '.join(ALLOWED_CONTENT_TYPES)} allowed."
             )
         contribution_db = mk_initial_contribution_candidate(contribution, request.user)
         out_file_name = contribution_db.id_persistent + extension


### PR DESCRIPTION
Allow more content types to fix issue with csv upload when using Firefox on Windows.
This allows more MIME types but treats them all as csv.